### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/miscsrc/check-osm-watch-list.pl
+++ b/miscsrc/check-osm-watch-list.pl
@@ -39,9 +39,9 @@ our $VERSION = '0.06';
 
 my $osm_watch_list = "$bbbike_rootdir/tmp/osm_watch_list";
 my $osm_file = "$bbbike_rootdir/misc/download/osm/berlin.osm.bz2";
-my $osm_api_url = 'https://www.openstreetmap.org/api/0.6';
+my $osm_api_url = 'https://api.openstreetmap.org/api/0.6';
 my $osm_url = 'https://www.openstreetmap.org';
-my $overpass_api_url = 'http://overpass-api.de/api/interpreter';
+my $overpass_api_url = 'https://overpass-api.de/api/interpreter';
 
 my $show_unchanged;
 my $quiet;

--- a/miscsrc/downloadosm
+++ b/miscsrc/downloadosm
@@ -36,10 +36,10 @@ our $VERSION = "0.04";
 use constant TIMEOUT => 60;
 
 use vars qw($OSM_API_URL);
-$OSM_API_URL = "http://www.openstreetmap.org/api/0.6";
-#$OSM_API_URL = "http://xapi.openstreetmap.org/api/0.6";
+$OSM_API_URL = "https://api.openstreetmap.org/api/0.6";
+#$OSM_API_URL = "https://xapi.openstreetmap.org/api/0.6";
 #$OSM_API_URL = "http://osmxapi.hypercube.telascience.org/api/0.6";
-#$OSM_API_URL = "http://www.informationfreeway.org/api/0.6";
+#$OSM_API_URL = "https://www.informationfreeway.org/api/0.6";
 
 my $ltlnqr = qr{([-+]?\d+(?:\.\d+)?)};
 my $osm_download_file_qr       = qr{/download_$ltlnqr,$ltlnqr,$ltlnqr,$ltlnqr\.osm(?:\.gz|\.bz2)?$};

--- a/miscsrc/osmelem2bbd
+++ b/miscsrc/osmelem2bbd
@@ -26,7 +26,7 @@ use Strassen::Core;
 sub get_node ($);
 sub get_way  ($);
 
-my $api_root_url = 'https://www.openstreetmap.org/api/0.6';
+my $api_root_url = 'https://api.openstreetmap.org/api/0.6';
 
 GetOptions
     or die "usage: $0 osmURL ...\n";

--- a/miscsrc/osmhistory
+++ b/miscsrc/osmhistory
@@ -36,7 +36,7 @@ GetOptions(
 	  )
     or die "usage: $0 [--no-pager] osmobject/id\n";
 
-my $api_root_url = "https://www.openstreetmap.org/api/0.6";
+my $api_root_url = "https://api.openstreetmap.org/api/0.6";
 
 my $elem = shift
     or die qq{Please specify osm element (e.g. "way/12345")\n};

--- a/miscsrc/osmnotes2bbd.pl
+++ b/miscsrc/osmnotes2bbd.pl
@@ -26,7 +26,7 @@ use Tie::IxHash;
 
 use Strassen::Core;
 
-my $osm_notes_rooturl_fmt = "http://www.openstreetmap.org/api/0.6/notes.json?limit=%d&closed=0&bbox=%s,%s,%s,%s";
+my $osm_notes_rooturl_fmt = "https://api.openstreetmap.org/api/0.6/notes.json?limit=%d&closed=0&bbox=%s,%s,%s,%s";
 
 my $o;
 my $bbox;


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)

Also changed some other urls which redirect from HTTP to HTTPS into HTTPS links.

cc: @eserte 