### PR TITLE
Update dafmap URL and add Elisp normalization

### DIFF
--- a/miscsrc/bbbike.el
+++ b/miscsrc/bbbike.el
@@ -567,7 +567,7 @@
   (if (null url)
       (setq url (bbbike--get-url-under-cursor)))
   (if (or (and bbbike-view-url-prefer-cached
-	       (not (string-match "^http://www.dafmap.de/" url)) ; depends on additional non-cached javascript files, cached version is not usable
+	       (not (string-match "^https?://\\(www\\.\\)?dafmap\\.de/" url)) ; depends on additional non-cached javascript files, cached version is not usable
 	       )
 	  (string-match "/___tmp/tmp/" url) ; temporary berlin.de URLs, usually only valid for a few minutes
 	  (string-match "//www.kulturbuch-verlag.de/Service/amtsblatt-fur-berlin/kostenloser-lese-service/pdfl/" url) ; old Amtsblatt URLs, not available anymore online
@@ -1097,6 +1097,10 @@
     (concat "https://bvv-tempelhof-schoeneberg.berlin.de/pi-r/vo020_r.asp" (match-string 1 url)))
    ((string-match "^https?://www\\.berlin\\.de/ba-treptow-koepenick/politik-und-verwaltung/bezirksverordnetenversammlung/online/vo020.asp\\(.*\\)" url)
     (concat "https://bvv-treptow-koepenick.berlin.de/pi-r/vo020_r.asp" (match-string 1 url)))
+   ((string-match "^https?://\\(?:www\\.\\)?dafmap\\.de/d/berlin\\.html\\?center=\\([0-9.]+\\)\\+\\([0-9.]+\\)\\(.*\\)" url)
+    (concat "https://dafmap.de/berlin?center=" (match-string 1 url) "," (match-string 2 url) (match-string 3 url)))
+   ((string-match "^https?://\\(?:www\\.\\)?dafmap\\.de/d/berlin\\.html\\(.*\\)" url)
+    (concat "https://dafmap.de/berlin" (match-string 1 url)))
    (t url)))
 
 ;;; make Mapillary URLs smaller

--- a/plugins/MultiMap.pm
+++ b/plugins/MultiMap.pm
@@ -1881,7 +1881,7 @@ sub showmap_url_daf_berlin {
     my $px = $args{px};
     my $py = $args{py};
     my $scale = 17 - log(($args{mapscale_scale})/3000)/log(2);
-    sprintf "http://www.dafmap.de/d/berlin.html?center=%s+%s&zoom=%d", $py, $px, $scale;
+    sprintf "https://dafmap.de/berlin?center=%s,%s&zoom=%d", $py, $px, $scale;
 }
 
 sub showmap_daf_berlin {


### PR DESCRIPTION
The dafmap (Deutsches Architekturforum) for Berlin/Potsdam has changed its URL structure and coordinate parameter format. 

This PR:
1. Updates the generated links in `plugins/MultiMap.pm` to the new `https://dafmap.de/berlin` format.
2. Updates the URL matching in `miscsrc/bbbike.el` to correctly identify all dafmap URLs.
3. Adds normalization logic to the `bbbike--normalize-url` Elisp function to transparently redirect old `dafmap.de/d/berlin.html` links (including those with `+` separated coordinates) to the new working format.

Historical data files are left unchanged as requested.

---
*PR created automatically by Jules for task [1274964294366728816](https://jules.google.com/task/1274964294366728816) started by @eserte*