### PR TITLE
Pin Template 3.103 for Perl 5.8.x compatibility in CI

### DIFF
--- a/port/ci/ci-functions.sh
+++ b/port/ci/ci-functions.sh
@@ -432,7 +432,7 @@ install_old_perl_dependencies() {
 		# Inline::C 0.77 (and probably newer) runs only on perl 5.10.0 and newer.
 		#
 		# non-commented modules increased the perl minimum version at some point in time
-		cpanm --quiet --notest DBD::XBase~"==0.234" File::Path DB_File~"!=1.833" Pegex~"==0.61" Inline::C~"==0.76" HTML::Tagset~"<3.22" XML::Twig~"<3.54"
+		cpanm --quiet --notest DBD::XBase~"==0.234" File::Path DB_File~"!=1.833" Pegex~"==0.61" Inline::C~"==0.76" HTML::Tagset~"<3.22" XML::Twig~"<3.54" Template~"==3.103"
 		;;
 	esac
 	case "$PERLBREW_PERL" in


### PR DESCRIPTION
The `Template` (Template Toolkit) module is no longer compatible with Perl 5.8.x starting from version 3.104. To maintain compatibility for CI environments running legacy Perl versions, I have updated the `install_old_perl_dependencies` function in `port/ci/ci-functions.sh` to pin the `Template` module to version `3.103` specifically for Perl 5.8.x.

Changes made:
- Modified `port/ci/ci-functions.sh` to add `Template~"==3.103"` to the `cpanm` installation list for Perl 5.8.
- Verified the script syntax and content.
- Recorded the dependency pinning in project memory for future reference.

---
*PR created automatically by Jules for task [11064585618342160559](https://jules.google.com/task/11064585618342160559) started by @eserte*