### PR TITLE
Add support for Berlin aerial images 2026

### DIFF
--- a/html/bbbikeleaflet.js
+++ b/html/bbbikeleaflet.js
@@ -373,7 +373,7 @@ function doLeaflet() {
     var cyclosmAttribution = '\u00a9 <a href="https://www.openstreetmap.org/">OpenStreetMap</a> Contributors. Tiles style by <a href="https://www.cyclosm.org">CyclOSM</a> hosted by <a href="https://openstreetmap.fr">OpenStreetMap France</a>';
     var cyclosmTileLayer = new L.TileLayer(cyclosmUrl, {maxZoom: 19, attribution: cyclosmAttribution});
 
-    var berlinAerialYear = '2025';
+    var berlinAerialYear = '2026';
     //var berlinAerialVariant = '-dop20rgbi';
     //var berlinAerialVariant = '-dop20rgb';
     var berlinAerialVariant = '-truedop20rgb';

--- a/html/bbbikeleaflet.js
+++ b/html/bbbikeleaflet.js
@@ -375,8 +375,8 @@ function doLeaflet() {
 
     var berlinAerialYear = '2026';
     //var berlinAerialVariant = '-dop20rgbi';
-    //var berlinAerialVariant = '-dop20rgb';
-    var berlinAerialVariant = '-truedop20rgb';
+    var berlinAerialVariant = '-dop20rgb';
+    //var berlinAerialVariant = '-truedop20rgb';
     var berlinAerialNewestUrl = 'https://tiles.codefor.de/berlin/geoportal/luftbilder/' + berlinAerialYear + berlinAerialVariant + '/{z}/{x}/{y}.png';
     //var berlinAerialAttribution = M("Kartendaten") + ': <a href="https://fbinter.stadt-berlin.de/fb/berlin/service_intern.jsp?id=a_luftbild' + berlinAerialYear + '_true_rgbi@senstadt&type=FEED">Geoportal Berlin / Digitale farbige TrueOrthophotos ' + berlinAerialYear + '</a>';
     var berlinAerialAttribution = M("Kartendaten") + ': Senatsverwaltung für Stadtentwicklung, Bauen und Wohnen Berlin / Digitale farbige Orthophotos ' + berlinAerialYear + ' (DOP20RGB)';

--- a/plugins/MultiMap.pm
+++ b/plugins/MultiMap.pm
@@ -1936,6 +1936,7 @@ sub showmap_url_gdi_berlin {
 	fluralkis          => 'hintergrund_k5_farbe,alkis_flurstuecke:flurstuecke',
 	flurinspire        => 'hintergrund_k5_farbe,cp_alkis:CP.CadastralZoning,cp_alkis:CP.CadastralParcel',
 	gruenanlagen       => 'hintergrund_k5_grau,gruenanlagen:spielplaetze,gruenanlagen:gruenanlagen',
+	ortho2026          => 'hintergrund_k5_grau,truedop_2026:truedop_2026',
 	ortho2025          => 'hintergrund_k5_grau,truedop_2025_sommer:truedop_2025_sommer_rgb',
 	ortho2025_fruehjahr=> 'hintergrund_k5_grau,dop_2025_fruehjahr:dop_2025',
 	ortho2024          => 'hintergrund_k5_grau,truedop_2024:truedop_2024',
@@ -2056,6 +2057,10 @@ sub show_gdi_berlin_menu {
 	 -command => sub { showmap_gdi_berlin(layers => 'gruenanlagen', %args) },
 	);
     $link_menu->separator;
+    $link_menu->command
+	(-label => 'Orthophotos 2026',
+	 -command => sub { showmap_gdi_berlin(layers => 'ortho2026', %args) },
+	);
     $link_menu->command
 	(-label => 'Orthophotos 2025',
 	 -command => sub { showmap_gdi_berlin(layers => 'ortho2025', %args) },

--- a/plugins/MultiMap.pm
+++ b/plugins/MultiMap.pm
@@ -26,8 +26,8 @@ use BBBikeUtil qw(bbbike_aux_dir module_exists deg2rad);
 use vars qw(%images);
 
 my $map_compare_use_bbbike_org = 1;
-my $newest_berlin_aerial_year = '2025'; # used in MapCompare and possibly Rapid
-my $newest_berlin_aerial = 'berlin-historical-'.$newest_berlin_aerial_year.'-summer';
+my $newest_berlin_aerial_year = '2026'; # used in MapCompare and possibly Rapid
+my $newest_berlin_aerial = 'berlin-historical-'.$newest_berlin_aerial_year.'-spring';
 
 $main::devel_host = $main::devel_host if 0; # cease -w
 
@@ -1557,12 +1557,12 @@ sub show_mapcompare_menu {
 	     # whole of Brandenburg
 	     showmap_mapcompare
 		 (maps => [qw(
+				 berlin-historical-2026-spring
 				 berlin-historical-2025-summer
 				 berlin-historical-2025
 				 berlin-historical-2024
 				 berlin-historical-2023
 				 berlin-historical-2022
-				 berlin-historical-2021
 				 lgb-satellite-color
 				 google-satellite
 			    )],


### PR DESCRIPTION
Updated the codebase to support the newly available 2026 aerial imagery of Berlin. Changes include:
- Added `ortho2026` mapping in `plugins/MultiMap.pm` using the `truedop_2026` ID.
- Added a "Orthophotos 2026" menu entry in the `MultiMap` plugin.
- Set `berlinAerialYear` to `'2026'` in `html/bbbikeleaflet.js` to make it the default year in the Leaflet map interface.

---
*PR created automatically by Jules for task [12890070893126833381](https://jules.google.com/task/12890070893126833381) started by @eserte*