### PR TITLE
Show OpenCage/geocoding errors in GUI dialog

### DIFF
--- a/plugins/GeocoderPlugin.pm
+++ b/plugins/GeocoderPlugin.pm
@@ -164,7 +164,7 @@ sub geocoder_dialog {
 		     my $apikey = do {
 			 my $file = "$ENV{HOME}/.opencageapikey";
 			 open my $fh, $file
-			     or main::status_message("Cannot get key from $file: $!", "die");
+			     or die "Cannot get key from $file: $!";
 			 local $_ = <$fh>;
 			 chomp;
 			 $_;
@@ -249,9 +249,7 @@ sub geocoder_dialog {
 	    my $mod = 'Geo::Coder::' . $geocoder_api;
 	    eval "require $mod";
 	}
-	if ($@) {
-	    main::status_message($@, "die");
-	}
+	die $@ if $@;
     };
 
     my $do_geocode = sub {
@@ -262,7 +260,6 @@ sub geocoder_dialog {
 	my $geocoder = $gc->{new}->();
 	my $location = $geocoder->geocode(location => $loc);
 	$gc->{fix_result}->($location) if $gc->{fix_result};
-	require Data::Dumper; print STDERR "Line " . __LINE__ . ", File: " . __FILE__ . "\n" . Data::Dumper->new([$location],[qw()])->Indent(1)->Useqq(1)->Dump; # XXX
 
 	$location;
     };
@@ -288,7 +285,10 @@ sub geocoder_dialog {
     my $change_geocoder = sub {
 	my $gc = $apis{$geocoder_api};
 	if ($gc->{suggest}) {
-	    $do_geocoder_init->($gc);
+	    eval { $do_geocoder_init->($gc) };
+	    if ($@) {
+		main::status_message($@, "die");
+	    }
 	    if ($can_choicescmd) {
 		$e->configure(-choicescmd => sub {
 				  my(undef, $text) = @_;
@@ -326,7 +326,11 @@ sub geocoder_dialog {
 	$bf->Button(Name => "ok",
 		    -command => sub {
 			my $gc = $apis{$geocoder_api};
-			my $location = $do_geocode->($gc, $get_loc->());
+			my $location = eval { $do_geocode->($gc, $get_loc->()) };
+			if ($@) {
+			    main::status_message($@, "die");
+			    return;
+			}
 			if ($location) {
 			    $res->delete("1.0", "end");
 			    $res->insert("end", $get_long_address->($gc, $location));
@@ -357,8 +361,10 @@ sub geocoder_dialog {
 				my $location = eval {
 				    $do_geocode->($gc, $get_loc->());
 				};
-				if ($@ || !$location) {
-				    warn "Could not geocode '" . $get_loc->() . "' with '$_api': $@";
+				if ($@) {
+				    main::status_message("Could not geocode '" . $get_loc->() . "' with '$_api': $@", "die");
+				} elsif (!$location) {
+				    warn "Could not geocode '" . $get_loc->() . "' with '$_api': no result";
 				} else {
 				    if ($gc->{include_multi_master}) {
 					$loc_addr = $get_long_address->($gc, $location);


### PR DESCRIPTION
This change improves the user experience when geocoding fails in the BBBike Geocoder plugin. Previously, certain errors (like an expired OpenCage API key resulting in a 401 response) would only be logged to the terminal, leaving the user with a generic "No result" message or no feedback at all in the GUI.

Key changes:
- Refactored `do_geocoder_init` to propagate errors using `die` instead of calling `main::status_message` internally.
- Wrapped geocoder initialization in `change_geocoder` with an `eval` block and GUI error reporting.
- Wrapped geocoding execution in the "OK" button callback with an `eval` block to catch and display API-level exceptions.
- Updated the "Multi" geocoding loop to report exceptions via GUI dialogs.
- Changed the OpenCage API key file reading logic to use `die` so it can be caught by the new error handling blocks.
- Cleaned up a `Data::Dumper` debug statement in `do_geocode`.

---
*PR created automatically by Jules for task [487921325826676976](https://jules.google.com/task/487921325826676976) started by @eserte*