### PR TITLE
Add miscsrc/vizhistory helper script and tests

### DIFF
--- a/miscsrc/vizhistory
+++ b/miscsrc/vizhistory
@@ -29,7 +29,7 @@ my $opt_all;
 my $opt_debug;
 my $use_pager = -t STDOUT && is_in_path('less');
 my $diff_context = 3;
-my $opt_process_buggy = 1;
+my $opt_process_buggy = 0;
 my $opt_help;
 
 GetOptions(
@@ -38,9 +38,9 @@ GetOptions(
     'debug'          => \$opt_debug,
     'pager!'         => \$use_pager,
     'diff-context=i' => \$diff_context,
-    'process-buggy!' => \$opt_process_buggy,
+    'process-buggy'  => \$opt_process_buggy,
     'help|h|?'       => \$opt_help,
-) or die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] [--no-process-buggy] <id>\n";
+) or die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] [--process-buggy] <id>\n";
 
 if ($opt_help) {
     print_usage();
@@ -49,7 +49,7 @@ if ($opt_help) {
 
 my $id = shift;
 if (!defined $id || $id eq "") {
-    die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] [--no-process-buggy] <id>\n";
+    die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] [--process-buggy] <id>\n";
 }
 
 if (!-d $archive_dir) {
@@ -300,7 +300,7 @@ Options:
   --debug              Show currently checked files on STDERR
   --no-pager           Disable automatic pager
   --diff-context <num> Set number of context lines for unified diff (default: 3)
-  --no-process-buggy   Stop scanning on old files <= 20130122 (default: process them)
+  --process-buggy      Process old files <= 20130122 (default: skip them)
   --help, -h           Show this help message
 EOF
 }

--- a/miscsrc/vizhistory
+++ b/miscsrc/vizhistory
@@ -1,0 +1,283 @@
+#!/usr/bin/env perl
+# -*- perl -*-
+
+#
+# Author: Slaven Rezic
+#
+# Copyright (C) 2026 Slaven Rezic. All rights reserved.
+# This program is free software; you can redistribute it and/or
+# modify it under the same terms as Perl itself.
+#
+# WWW:  https://github.com/eserte/bbbike
+#
+
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::RealBin/..", "$FindBin::RealBin/../lib";
+
+use Getopt::Long;
+use File::Temp;
+use BBBikeUtil qw(is_in_path);
+use BBBikeYAML;
+
+my $archive_dir = "$ENV{HOME}/src/bbbike-viz/archive";
+my $opt_all;
+my $opt_debug;
+my $use_pager = -t STDOUT && is_in_path('less');
+my $diff_context = 3;
+my $opt_help;
+
+GetOptions(
+    'dir=s'          => \$archive_dir,
+    'all'            => \$opt_all,
+    'debug'          => \$opt_debug,
+    'pager!'         => \$use_pager,
+    'diff-context=i' => \$diff_context,
+    'help|h|?'       => \$opt_help,
+) or die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] <id>\n";
+
+if ($opt_help) {
+    print_usage();
+    exit 0;
+}
+
+my $id = shift;
+if (!defined $id || $id eq "") {
+    die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] <id>\n";
+}
+
+if (!-d $archive_dir) {
+    die "Error: Archive directory '$archive_dir' does not exist\n";
+}
+
+my @files;
+if (opendir(my $dh, $archive_dir)) {
+    while (my $entry = readdir($dh)) {
+        next if $entry =~ /^\.\.?$/;
+        if ($entry =~ /^newvmz-(\d{8})\.yaml$/) {
+            push @files, {
+                path => "$archive_dir/$entry",
+                date => $1,
+                name => $entry,
+            };
+        } elsif ($entry =~ /^\d{4}$/ && -d "$archive_dir/$entry") {
+            if (opendir(my $subdh, "$archive_dir/$entry")) {
+                while (my $subentry = readdir($subdh)) {
+                    if ($subentry =~ /^newvmz-(\d{8})\.yaml$/) {
+                        push @files, {
+                            path => "$archive_dir/$entry/$subentry",
+                            date => $1,
+                            name => "$entry/$subentry",
+                        };
+                    }
+                }
+                closedir($subdh);
+            }
+        }
+    }
+    closedir($dh);
+} else {
+    die "Error: Cannot open directory '$archive_dir': $!\n";
+}
+
+if (!@files) {
+    print STDERR "Error: No VIZ archive files found in '$archive_dir'\n";
+    exit 1;
+}
+
+@files = sort { $b->{date} <=> $a->{date} } @files;
+
+if ($use_pager) {
+    my @pager_cmd = ('less', '-S');
+    open STDOUT, '|-', @pager_cmd
+	or die "Failed to run '@pager_cmd': $!";
+}
+binmode STDOUT, ':utf8';
+
+my $found_at_least_once = 0;
+my @history; # to store versions of payload
+my $files_checked = 0;
+my $last_debug_time = time;
+
+for my $file (@files) {
+    $files_checked++;
+    if ($opt_debug) {
+        my $now = time;
+        if ($files_checked % 100 == 0 || $now - $last_debug_time >= 3) {
+            print STDERR "Checking file: $file->{name} ($files_checked files checked...)\n";
+            $last_debug_time = $now;
+        }
+    }
+
+    my ($payload, $matched_key) = lookup_id_in_file($file->{path}, $id);
+    if ($payload) {
+        $found_at_least_once = 1;
+        push @history, {
+            file        => $file,
+            payload     => $payload,
+            matched_key => $matched_key,
+        };
+    } else {
+        if ($found_at_least_once && !$opt_all) {
+            last;
+        }
+        if (!$opt_all) {
+            last;
+        }
+    }
+}
+
+if (!$found_at_least_once) {
+    print STDERR "Error: ID '$id' was never found in the archive.\n";
+    exit 1;
+}
+
+# Print the history starting from the newest to the oldest found
+for (my $i = 0; $i <= $#history; $i++) {
+    my $current_entry = $history[$i];
+    my $older_entry = ($i < $#history) ? $history[$i+1] : undef;
+
+    my $newer_fh = File::Temp->new(TEMPLATE => "vizhistory_XXXXXXXX", TMPDIR => 1);
+    my $newer_content = dump_sorted($current_entry->{payload});
+    $newer_fh->print($newer_content);
+    $newer_fh->flush;
+
+    my $older_path;
+    my $old_version_label;
+    my $older_fh;
+    if ($older_entry) {
+        $older_fh = File::Temp->new(TEMPLATE => "vizhistory_XXXXXXXX", TMPDIR => 1);
+        my $older_content = dump_sorted($older_entry->{payload});
+        $older_fh->print($older_content);
+        $older_fh->flush;
+        $older_path = $older_fh->filename;
+        $old_version_label = $older_entry->{file}->{date};
+    } else {
+        $older_path = "/dev/null";
+        $old_version_label = "0";
+    }
+
+    my $new_version_label = $current_entry->{file}->{date};
+
+    print "="x70, "\n";
+    print "ID: $id";
+    if (defined $current_entry->{matched_key} && $current_entry->{matched_key} ne $id) {
+        print " (Key: $current_entry->{matched_key})";
+    }
+    print "\n";
+    print "File: $current_entry->{file}->{name}\n";
+
+    my $formatted_date = $current_entry->{file}->{date};
+    if ($formatted_date =~ /^(\d{4})(\d{2})(\d{2})$/) {
+        $formatted_date = "$1-$2-$3";
+    }
+    print "Date: $formatted_date\n\n";
+
+    open my $fh, '-|', 'diff', "--label=$old_version_label", "--label=$new_version_label", "--unified=$diff_context", $older_path, $newer_fh->filename
+        or die "Error while running diff command: $!";
+    while (<$fh>) {
+        next if /^\@\@/;
+        print $_;
+    }
+    print "\n";
+}
+
+close STDOUT;
+
+sub lookup_id_in_file {
+    my ($file_path, $id) = @_;
+
+    my $data = eval { BBBikeYAML::LoadFile($file_path) };
+    if ($@) {
+        warn "Warning: Failed to load YAML file '$file_path': $@\n" if $opt_debug;
+        return;
+    }
+    if (!$data || ref $data ne 'HASH' || !exists $data->{id2rec}) {
+        return;
+    }
+
+    my $id2rec = $data->{id2rec};
+    if (ref $id2rec ne 'HASH') {
+        return;
+    }
+
+    if (exists $id2rec->{$id}) {
+        return ($id2rec->{$id}, $id);
+    }
+
+    for my $key (keys %$id2rec) {
+        my $rec = $id2rec->{$key};
+        if (ref $rec eq 'HASH') {
+            if (defined $rec->{viz2025_id} && $rec->{viz2025_id} eq $id) {
+                return ($rec, $key);
+            }
+        }
+    }
+
+    return;
+}
+
+sub dump_sorted {
+    my ($val, $indent) = @_;
+    $indent //= 0;
+    my $sp = " " x $indent;
+    if (!defined $val) {
+        return "null\n";
+    } elsif (ref $val eq 'HASH') {
+        my $res = "";
+        for my $k (sort keys %$val) {
+            my $v = $val->{$k};
+            if (ref $v) {
+                $res .= "$sp$k:\n" . dump_sorted($v, $indent + 2);
+            } else {
+                my $v_str = defined $v ? $v : "null";
+                if ($v_str =~ /\n/) {
+                    my $ind_sp = " " x ($indent + 2);
+                    $v_str =~ s/^/$ind_sp/mg;
+                    $v_str =~ s/\s+$//;
+                    $res .= "$sp$k: |\n$v_str\n";
+                } else {
+                    $res .= "$sp$k: $v_str\n";
+                }
+            }
+        }
+        return $res;
+    } elsif (ref $val eq 'ARRAY') {
+        my $res = "";
+        for my $item (@$val) {
+            if (ref $item) {
+                my $dumped = dump_sorted($item, $indent + 2);
+                $dumped =~ s/^\s{2}/- /;
+                $res .= $dumped;
+            } else {
+                my $v_str = defined $item ? $item : "null";
+                if ($v_str =~ /\n/) {
+                    my $ind_sp = " " x ($indent + 2);
+                    $v_str =~ s/^/$ind_sp/mg;
+                    $v_str =~ s/\s+$//;
+                    $res .= "$sp- |\n$v_str\n";
+                } else {
+                    $res .= "$sp- $v_str\n";
+                }
+            }
+        }
+        return $res;
+    } else {
+        return "$sp$val\n";
+    }
+}
+
+sub print_usage {
+    print <<EOF;
+usage: $0 [options] <id>
+
+Options:
+  --dir <dir>          Set the VIZ archive directory (default: ~/src/bbbike-viz/archive)
+  --all                Search until the very first file (do not stop on missing ID)
+  --debug              Show currently checked files on STDERR
+  --no-pager           Disable automatic pager
+  --diff-context <num> Set number of context lines for unified diff (default: 3)
+  --help, -h           Show this help message
+EOF
+}

--- a/miscsrc/vizhistory
+++ b/miscsrc/vizhistory
@@ -29,7 +29,7 @@ my $opt_all;
 my $opt_debug;
 my $use_pager = -t STDOUT && is_in_path('less');
 my $diff_context = 3;
-my $opt_process_buggy;
+my $opt_process_buggy = 1;
 my $opt_help;
 
 GetOptions(
@@ -38,9 +38,9 @@ GetOptions(
     'debug'          => \$opt_debug,
     'pager!'         => \$use_pager,
     'diff-context=i' => \$diff_context,
-    'process-buggy'  => \$opt_process_buggy,
+    'process-buggy!' => \$opt_process_buggy,
     'help|h|?'       => \$opt_help,
-) or die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] [--process-buggy] <id>\n";
+) or die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] [--no-process-buggy] <id>\n";
 
 if ($opt_help) {
     print_usage();
@@ -49,7 +49,7 @@ if ($opt_help) {
 
 my $id = shift;
 if (!defined $id || $id eq "") {
-    die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] [--process-buggy] <id>\n";
+    die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] [--no-process-buggy] <id>\n";
 }
 
 if (!-d $archive_dir) {
@@ -108,7 +108,7 @@ my $last_debug_time = time;
 my $effective_stop_date = $opt_process_buggy ? undef : $stop_on_buggy_date;
 
 for my $file (@files) {
-    if (defined $effective_stop_date && $file->{date} <= $effective_stop_date) {
+    if (defined $effective_stop_date && $file->{date} le $effective_stop_date) {
         if ($opt_debug) {
             print STDERR "Stopping search because file date $file->{date} is older than or equal to $effective_stop_date.\n";
         }
@@ -300,7 +300,7 @@ Options:
   --debug              Show currently checked files on STDERR
   --no-pager           Disable automatic pager
   --diff-context <num> Set number of context lines for unified diff (default: 3)
-  --process-buggy      Process old files <= 20130122 (default: skip them)
+  --no-process-buggy   Stop scanning on old files <= 20130122 (default: process them)
   --help, -h           Show this help message
 EOF
 }

--- a/miscsrc/vizhistory
+++ b/miscsrc/vizhistory
@@ -21,11 +21,15 @@ use File::Temp;
 use BBBikeUtil qw(is_in_path);
 use BBBikeYAML;
 
+# Set to a YYYYMMDD date to stop before buggy older files, or undef to disable.
+my $stop_on_buggy_date = '20130122';
+
 my $archive_dir = "$ENV{HOME}/src/bbbike-viz/archive";
 my $opt_all;
 my $opt_debug;
 my $use_pager = -t STDOUT && is_in_path('less');
 my $diff_context = 3;
+my $opt_process_buggy;
 my $opt_help;
 
 GetOptions(
@@ -34,8 +38,9 @@ GetOptions(
     'debug'          => \$opt_debug,
     'pager!'         => \$use_pager,
     'diff-context=i' => \$diff_context,
+    'process-buggy'  => \$opt_process_buggy,
     'help|h|?'       => \$opt_help,
-) or die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] <id>\n";
+) or die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] [--process-buggy] <id>\n";
 
 if ($opt_help) {
     print_usage();
@@ -44,7 +49,7 @@ if ($opt_help) {
 
 my $id = shift;
 if (!defined $id || $id eq "") {
-    die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] <id>\n";
+    die "usage: $0 [--dir <dir>] [--all] [--debug] [--no-pager] [--diff-context <num>] [--process-buggy] <id>\n";
 }
 
 if (!-d $archive_dir) {
@@ -100,7 +105,16 @@ my @history; # to store versions of payload
 my $files_checked = 0;
 my $last_debug_time = time;
 
+my $effective_stop_date = $opt_process_buggy ? undef : $stop_on_buggy_date;
+
 for my $file (@files) {
+    if (defined $effective_stop_date && $file->{date} <= $effective_stop_date) {
+        if ($opt_debug) {
+            print STDERR "Stopping search because file date $file->{date} is older than or equal to $effective_stop_date.\n";
+        }
+        last;
+    }
+
     $files_checked++;
     if ($opt_debug) {
         my $now = time;
@@ -160,27 +174,35 @@ for (my $i = 0; $i <= $#history; $i++) {
 
     my $new_version_label = $current_entry->{file}->{date};
 
-    print "="x70, "\n";
-    print "ID: $id";
-    if (defined $current_entry->{matched_key} && $current_entry->{matched_key} ne $id) {
-        print " (Key: $current_entry->{matched_key})";
-    }
-    print "\n";
-    print "File: $current_entry->{file}->{name}\n";
-
-    my $formatted_date = $current_entry->{file}->{date};
-    if ($formatted_date =~ /^(\d{4})(\d{2})(\d{2})$/) {
-        $formatted_date = "$1-$2-$3";
-    }
-    print "Date: $formatted_date\n\n";
-
+    # Generate the diff and check if it has content
+    my @diff_lines;
     open my $fh, '-|', 'diff', "--label=$old_version_label", "--label=$new_version_label", "--unified=$diff_context", $older_path, $newer_fh->filename
         or die "Error while running diff command: $!";
     while (<$fh>) {
         next if /^\@\@/;
-        print $_;
+        push @diff_lines, $_;
     }
-    print "\n";
+    close $fh;
+
+    # Only print anything if the diff is not empty
+    if (@diff_lines) {
+        print "="x70, "\n";
+        print "ID: $id";
+        if (defined $current_entry->{matched_key} && $current_entry->{matched_key} ne $id) {
+            print " (Key: $current_entry->{matched_key})";
+        }
+        print "\n";
+        print "File: $current_entry->{file}->{name}\n";
+
+        my $formatted_date = $current_entry->{file}->{date};
+        if ($formatted_date =~ /^(\d{4})(\d{2})(\d{2})$/) {
+            $formatted_date = "$1-$2-$3";
+        }
+        print "Date: $formatted_date\n\n";
+
+        print @diff_lines;
+        print "\n";
+    }
 }
 
 close STDOUT;
@@ -278,6 +300,7 @@ Options:
   --debug              Show currently checked files on STDERR
   --no-pager           Disable automatic pager
   --diff-context <num> Set number of context lines for unified diff (default: 3)
+  --process-buggy      Process old files <= 20130122 (default: skip them)
   --help, -h           Show this help message
 EOF
 }

--- a/t/miscsrc.t
+++ b/t/miscsrc.t
@@ -144,6 +144,9 @@ for my $f (@files) {
 	    if $f =~ m{/( bvg_disruptions_format.pl
 		       |  mapillary-v4-fetch                  
 		       )$}x && !eval { require Time::Moment; 1 };
+	myskip "$f works only with installed YAML::XS", 1
+	    if $f =~ m{/( vizhistory
+		       )$}x && !eval { require YAML::XS; 1 };
 
 	my @add_opts;
 	if ($f =~ m{\.pm$}) {

--- a/t/vizhistory.t
+++ b/t/vizhistory.t
@@ -24,13 +24,14 @@ if (!eval { require YAML::XS; 1 }) {
     plan skip_all => 'YAML::XS not available';
 }
 
-plan tests => 14;
+plan tests => 21;
 
 # Setup mock archive directory
 my $tempdir = tempdir(CLEANUP => 1);
 my $archive_dir = "$tempdir/archive";
 make_path($archive_dir) or die "Cannot create mock archive dir: $!";
 make_path("$archive_dir/2024") or die "Cannot create mock 2024 dir: $!";
+make_path("$archive_dir/2013") or die "Cannot create mock 2013 dir: $!";
 
 # Write mock YAML files
 write_file_content("$archive_dir/2024/newvmz-20241231.yaml", <<'EOF');
@@ -63,6 +64,33 @@ id2rec:
     text: "only in newest"
 EOF
 
+# Same content as 20250103 to test skipping empty diffs
+write_file_content("$archive_dir/newvmz-20250104.yaml", <<'EOF');
+id2rec:
+  viz2021:13,52:
+    id: viz2021:13,52
+    text: "third version"
+    viz2025_id: LMS:123/45
+  new_id:
+    id: new_id
+    text: "only in newest"
+EOF
+
+# Buggy older files to test stopping on buggy dates
+write_file_content("$archive_dir/2013/newvmz-20130122.yaml", <<'EOF');
+id2rec:
+  buggy_id:
+    id: buggy_id
+    text: "buggy 20130122"
+EOF
+
+write_file_content("$archive_dir/2013/newvmz-20130121.yaml", <<'EOF');
+id2rec:
+  buggy_id:
+    id: buggy_id
+    text: "buggy 20130121"
+EOF
+
 my $vizhistory_cmd = "$^X -I$FindBin::RealBin/.. -I$FindBin::RealBin/../lib $FindBin::RealBin/../miscsrc/vizhistory";
 
 # Case: Direct key lookup of new_id (only in newest, stop immediately on next)
@@ -73,11 +101,15 @@ my $vizhistory_cmd = "$^X -I$FindBin::RealBin/.. -I$FindBin::RealBin/../lib $Fin
 
     is($exit_code, 0, "Exit code is 0 for new_id lookup");
     like($output, qr/ID: new_id/, "Output contains correct ID header");
-    like($output, qr/File: newvmz-20250103\.yaml/, "Output contains newest filename");
+    like($output, qr/File: newvmz-20250103\.yaml/, "Output contains filename with changes");
     like($output, qr/\+text: only in newest/, "Output contains diff of text");
+
+    # 20250104 has identical content for new_id as 20250103. The transition has an empty diff,
+    # so it should be skipped and 20250104 should not be shown.
+    unlike($output, qr/File: newvmz-20250104\.yaml/, "Output skips identical version (empty diff) for 20250104");
 }
 
-# Case: viz2025_id lookup of LMS:123/45 (present in all versions)
+# Case: viz2025_id lookup of LMS:123/45 (present in all versions, with empty diff between 20250103 and 20250104)
 {
     my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager LMS:123/45";
     my $output = `$cmd 2>&1`;
@@ -87,6 +119,9 @@ my $vizhistory_cmd = "$^X -I$FindBin::RealBin/.. -I$FindBin::RealBin/../lib $Fin
     like($output, qr/File: newvmz-20250103\.yaml/, "Output contains newest file header");
     like($output, qr/File: newvmz-20250102\.yaml/, "Output contains middle file header");
     like($output, qr/File: 2024\/newvmz-20241231\.yaml/, "Output contains oldest file header in subdirectory");
+
+    # Transition between 20250103 and 20250104 is identical, so 20250104 should not be shown.
+    unlike($output, qr/File: newvmz-20250104\.yaml/, "Output skips identical version (empty diff) of LMS:123/45 for 20250104");
 }
 
 # Case: Direct key lookup of other_id (without --all, should stop at newest and exit with error)
@@ -117,6 +152,28 @@ my $vizhistory_cmd = "$^X -I$FindBin::RealBin/.. -I$FindBin::RealBin/../lib $Fin
     my $exit_code = $? >> 8;
 
     is($exit_code, 1, "Exit code is 1 when non-existent ID lookup is run with --all");
+}
+
+# Case: Verify stop_on_buggy_date behaviour (by default, stops on <= 20130122)
+{
+    my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager --all buggy_id";
+    my $output = `$cmd 2>&1`;
+    my $exit_code = $? >> 8;
+
+    # Should exit with error and "never found" because 20130122 and older were not processed.
+    is($exit_code, 1, "Exit code is 1 because buggy dates <= 20130122 are stopped/skipped by default");
+    like($output, qr/Error: ID 'buggy_id' was never found/, "Output shows never found error");
+}
+
+# Case: Verify override with --process-buggy (processes buggy dates <= 20130122)
+{
+    my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager --all --process-buggy buggy_id";
+    my $output = `$cmd 2>&1`;
+    my $exit_code = $? >> 8;
+
+    is($exit_code, 0, "Exit code is 0 with --process-buggy");
+    like($output, qr/File: 2013\/newvmz-20130122\.yaml/, "Output contains 20130122");
+    like($output, qr/File: 2013\/newvmz-20130121\.yaml/, "Output contains 20130121");
 }
 
 sub write_file_content {

--- a/t/vizhistory.t
+++ b/t/vizhistory.t
@@ -1,0 +1,127 @@
+#!/usr/bin/env perl
+# -*- perl -*-
+
+#
+# Author: Slaven Rezic
+#
+# Copyright (C) 2026 Slaven Rezic. All rights reserved.
+# This program is free software; you can redistribute it and/or
+# modify it under the same terms as Perl itself.
+#
+# WWW:  https://github.com/eserte/bbbike
+#
+
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::RealBin/..", "$FindBin::RealBin/../lib";
+
+use File::Temp qw(tempdir);
+use File::Path qw(make_path);
+use Test::More;
+
+if (!eval { require YAML::XS; 1 }) {
+    plan skip_all => 'YAML::XS not available';
+}
+
+plan tests => 14;
+
+# Setup mock archive directory
+my $tempdir = tempdir(CLEANUP => 1);
+my $archive_dir = "$tempdir/archive";
+make_path($archive_dir) or die "Cannot create mock archive dir: $!";
+make_path("$archive_dir/2024") or die "Cannot create mock 2024 dir: $!";
+
+# Write mock YAML files
+write_file_content("$archive_dir/2024/newvmz-20241231.yaml", <<'EOF');
+id2rec:
+  viz2021:13,52:
+    id: viz2021:13,52
+    text: "first version"
+    viz2025_id: LMS:123/45
+  other_id:
+    id: other_id
+    text: "only in oldest"
+EOF
+
+write_file_content("$archive_dir/newvmz-20250102.yaml", <<'EOF');
+id2rec:
+  viz2021:13,52:
+    id: viz2021:13,52
+    text: "second version"
+    viz2025_id: LMS:123/45
+EOF
+
+write_file_content("$archive_dir/newvmz-20250103.yaml", <<'EOF');
+id2rec:
+  viz2021:13,52:
+    id: viz2021:13,52
+    text: "third version"
+    viz2025_id: LMS:123/45
+  new_id:
+    id: new_id
+    text: "only in newest"
+EOF
+
+my $vizhistory_cmd = "$^X -I$FindBin::RealBin/.. -I$FindBin::RealBin/../lib $FindBin::RealBin/../miscsrc/vizhistory";
+
+# Case: Direct key lookup of new_id (only in newest, stop immediately on next)
+{
+    my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager new_id";
+    my $output = `$cmd 2>&1`;
+    my $exit_code = $? >> 8;
+
+    is($exit_code, 0, "Exit code is 0 for new_id lookup");
+    like($output, qr/ID: new_id/, "Output contains correct ID header");
+    like($output, qr/File: newvmz-20250103\.yaml/, "Output contains newest filename");
+    like($output, qr/\+text: only in newest/, "Output contains diff of text");
+}
+
+# Case: viz2025_id lookup of LMS:123/45 (present in all versions)
+{
+    my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager LMS:123/45";
+    my $output = `$cmd 2>&1`;
+    my $exit_code = $? >> 8;
+
+    is($exit_code, 0, "Exit code is 0 for viz2025_id lookup");
+    like($output, qr/File: newvmz-20250103\.yaml/, "Output contains newest file header");
+    like($output, qr/File: newvmz-20250102\.yaml/, "Output contains middle file header");
+    like($output, qr/File: 2024\/newvmz-20241231\.yaml/, "Output contains oldest file header in subdirectory");
+}
+
+# Case: Direct key lookup of other_id (without --all, should stop at newest and exit with error)
+{
+    my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager other_id";
+    my $output = `$cmd 2>&1`;
+    my $exit_code = $? >> 8;
+
+    is($exit_code, 1, "Exit code is 1 when ID is not found under default behavior");
+    like($output, qr/Error: ID 'other_id' was never found in the archive\./, "Output has correct error message");
+}
+
+# Case: Direct key lookup of other_id with --all (should skip newest, find it in oldest, exit 0)
+{
+    my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager --all other_id";
+    my $output = `$cmd 2>&1`;
+    my $exit_code = $? >> 8;
+
+    is($exit_code, 0, "Exit code is 0 with --all option for other_id");
+    like($output, qr/File: 2024\/newvmz-20241231\.yaml/, "Output contains oldest file header with --all option");
+    like($output, qr/\+text: only in oldest/, "Output contains correct diff for oldest file");
+}
+
+# Case: Non-existent ID lookup with --all
+{
+    my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager --all non_existent_id";
+    my $output = `$cmd 2>&1`;
+    my $exit_code = $? >> 8;
+
+    is($exit_code, 1, "Exit code is 1 when non-existent ID lookup is run with --all");
+}
+
+sub write_file_content {
+    my ($file, $content) = @_;
+    open my $fh, '>', $file or die "Cannot write to $file: $!";
+    print $fh $content;
+    close $fh;
+}

--- a/t/vizhistory.t
+++ b/t/vizhistory.t
@@ -154,26 +154,25 @@ my $vizhistory_cmd = "$^X -I$FindBin::RealBin/.. -I$FindBin::RealBin/../lib $Fin
     is($exit_code, 1, "Exit code is 1 when non-existent ID lookup is run with --all");
 }
 
-# Case: Verify stop_on_buggy_date behaviour (by default, stops on <= 20130122)
+# Case: Verify stop_on_buggy_date behaviour (by default, processed)
 {
     my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager --all buggy_id";
     my $output = `$cmd 2>&1`;
     my $exit_code = $? >> 8;
 
-    # Should exit with error and "never found" because 20130122 and older were not processed.
-    is($exit_code, 1, "Exit code is 1 because buggy dates <= 20130122 are stopped/skipped by default");
-    like($output, qr/Error: ID 'buggy_id' was never found/, "Output shows never found error");
+    is($exit_code, 0, "Exit code is 0 because buggy dates <= 20130122 are processed by default");
+    like($output, qr/File: 2013\/newvmz-20130122\.yaml/, "Output contains 20130122");
+    like($output, qr/File: 2013\/newvmz-20130121\.yaml/, "Output contains 20130121");
 }
 
-# Case: Verify override with --process-buggy (processes buggy dates <= 20130122)
+# Case: Verify override with --no-process-buggy (stops/skips on buggy dates <= 20130122)
 {
-    my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager --all --process-buggy buggy_id";
+    my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager --all --no-process-buggy buggy_id";
     my $output = `$cmd 2>&1`;
     my $exit_code = $? >> 8;
 
-    is($exit_code, 0, "Exit code is 0 with --process-buggy");
-    like($output, qr/File: 2013\/newvmz-20130122\.yaml/, "Output contains 20130122");
-    like($output, qr/File: 2013\/newvmz-20130121\.yaml/, "Output contains 20130121");
+    is($exit_code, 1, "Exit code is 1 with --no-process-buggy");
+    like($output, qr/Error: ID 'buggy_id' was never found/, "Output shows never found error with --no-process-buggy");
 }
 
 sub write_file_content {

--- a/t/vizhistory.t
+++ b/t/vizhistory.t
@@ -154,25 +154,25 @@ my $vizhistory_cmd = "$^X -I$FindBin::RealBin/.. -I$FindBin::RealBin/../lib $Fin
     is($exit_code, 1, "Exit code is 1 when non-existent ID lookup is run with --all");
 }
 
-# Case: Verify stop_on_buggy_date behaviour (by default, processed)
+# Case: Verify stop_on_buggy_date behaviour (by default, stops on <= 20130122)
 {
     my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager --all buggy_id";
     my $output = `$cmd 2>&1`;
     my $exit_code = $? >> 8;
 
-    is($exit_code, 0, "Exit code is 0 because buggy dates <= 20130122 are processed by default");
-    like($output, qr/File: 2013\/newvmz-20130122\.yaml/, "Output contains 20130122");
-    like($output, qr/File: 2013\/newvmz-20130121\.yaml/, "Output contains 20130121");
+    is($exit_code, 1, "Exit code is 1 because buggy dates <= 20130122 are stopped/skipped by default");
+    like($output, qr/Error: ID 'buggy_id' was never found/, "Output shows never found error");
 }
 
-# Case: Verify override with --no-process-buggy (stops/skips on buggy dates <= 20130122)
+# Case: Verify override with --process-buggy (processes buggy dates <= 20130122)
 {
-    my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager --all --no-process-buggy buggy_id";
+    my $cmd = "$vizhistory_cmd --dir $archive_dir --no-pager --all --process-buggy buggy_id";
     my $output = `$cmd 2>&1`;
     my $exit_code = $? >> 8;
 
-    is($exit_code, 1, "Exit code is 1 with --no-process-buggy");
-    like($output, qr/Error: ID 'buggy_id' was never found/, "Output shows never found error with --no-process-buggy");
+    is($exit_code, 0, "Exit code is 0 with --process-buggy");
+    like($output, qr/File: 2013\/newvmz-20130122\.yaml/, "Output contains 20130122");
+    like($output, qr/File: 2013\/newvmz-20130121\.yaml/, "Output contains 20130121");
 }
 
 sub write_file_content {


### PR DESCRIPTION
Added the helper script miscsrc/vizhistory to show unified diffs of historical VIZ records. Also added its associated unit tests in t/vizhistory.t, and integrated it into the main test script t/miscsrc.t with a skip rule when YAML::XS is not available.

---
*PR created automatically by Jules for task [18137419922597845941](https://jules.google.com/task/18137419922597845941) started by @eserte*