### PR TITLE
Support -addwidgetcb and Hashrefs in choose_ort splitter

### DIFF
--- a/bbbike
+++ b/bbbike
@@ -12188,6 +12188,7 @@ sub choose_ort {
 	$sorted = "unsorted";
     }
     my $splitter = $args{-splitter};
+    my $addwidgetcb = $args{-addwidgetcb};
     my $columnwidths = $args{-columnwidths};
     my $container = $args{-container};
     my $do_popup = exists $args{-popup} ? $args{-popup} : 1;
@@ -12355,7 +12356,7 @@ sub choose_ort {
 	    $conv = $object && $object->get_conversion;
 
 	    my $Listbox = "Listbox";
-	    if ($splitter) {
+	    if ($splitter || $addwidgetcb) {
 		$Listbox = "HList";
 	    } else {
 		if ($sorted eq 'alphabetic') {
@@ -12467,11 +12468,14 @@ sub choose_ort {
 		my(@cols) = $splitter->($first_ort, $first_index);
 		$max_cols = scalar @cols;
 	    }
+	    if ($addwidgetcb) {
+		$max_cols = ($max_cols || 1) + 1;
+	    }
 
 	    $lb = $t->Scrolled($Listbox,
 			       -scrollbars => 'osoe',
 			       -selectmode => 'single',
-			       ($splitter
+			       (($splitter || $addwidgetcb)
 				? (-columns => $max_cols,
 				   -exportselection => 1,
 				  )
@@ -12480,7 +12484,7 @@ sub choose_ort {
 			      )->pack(-expand => 1, -fill => 'both');
 	    $t->Advertise(Listbox => $lb->Subwidget("scrolled"));
 
-	    if ($splitter) {
+	    if ($splitter || $addwidgetcb) {
 		my @wraplength;
 		if ($columnwidths) {
 		    @wraplength = @$columnwidths;
@@ -12496,19 +12500,57 @@ sub choose_ort {
 		my $inx = 0;
 		# XXX no support for sort styles here XXX
 		for my $ort (sort keys %orte) {
-		    my(@cols) = $splitter->($ort, $orte{$ort});
+		    my(@cols);
+		    if ($splitter) {
+			@cols = $splitter->($ort, $orte{$ort});
+		    } else {
+			@cols = ($ort);
+		    }
+
+		    my $col_val0 = $cols[0];
+		    my @add_args;
+		    if (ref $col_val0 eq 'HASH') {
+			if (my $cb = $col_val0->{cb}) {
+			    my $w = $cb->($lb, $col_val0);
+			    @add_args = (-itemtype => 'window', -window => $w);
+			} else {
+			    @add_args = (-text => $col_val0->{text});
+			}
+		    } else {
+			@add_args = (-text => $col_val0, -style => $text_style[0]);
+		    }
+
 		    $lb->add($inx,
-			     -text => $cols[0],
+			     @add_args,
 			     -data => $ort,
-			     -style => $text_style[0],
 			    );
 		    for my $col (1 .. $#cols) {
-			next if $col > $max_cols; # XXX off by one?
+			next if $col >= $max_cols;
+			my $col_val = $cols[$col];
+			my @item_args;
+			if (ref $col_val eq 'HASH') {
+			    if (my $cb = $col_val->{cb}) {
+				my $w = $cb->($lb, $col_val);
+				@item_args = (-itemtype => 'window', -window => $w);
+			    } else {
+				@item_args = (-text => $col_val->{text});
+			    }
+			} else {
+			    @item_args = (-text => $col_val, -style => $text_style[$col]);
+			}
 			$lb->itemCreate($inx, $col,
-					-text => $cols[$col],
-					-style => $text_style[$col],
+					@item_args,
 				       );
 		    }
+
+		    if ($addwidgetcb) {
+			my $w = $addwidgetcb->($lb, $ort, $orte{$ort});
+			$lb->itemCreate($inx, $max_cols - 1,
+					-itemtype => 'window',
+					-window => $w,
+				       );
+		    }
+
 		    $inx++;
 		}
 		# XXX destroy text_styles?
@@ -12553,7 +12595,7 @@ sub choose_ort {
 
 	    my $show_sub =  sub {
 		my %args = @_;
-		my $lb_index = ($splitter
+		my $lb_index = (($splitter || $addwidgetcb)
 				? $lb->info('anchor')
 				: $lb->index('active')
 			       );
@@ -12562,7 +12604,7 @@ sub choose_ort {
 		if ($sorted eq 'unsorted') {
 		    $index = $lb_index;
 		} else {
-		    my $ort = ($splitter
+		    my $ort = (($splitter || $addwidgetcb)
 			       ? $lb->info("data", $lb_index)
 			       : $lb->get($lb_index)
 			      );
@@ -12690,7 +12732,7 @@ sub choose_ort {
 	    my $find_and_select_nearest = sub {
 		my($w, $y) = @_;
 		my $inx = $w->nearest($y);
-		if ($splitter) {
+		if ($splitter || $addwidgetcb) {
 		    $w->selectionClear;
 		    $w->selectionSet($inx);
 		    $w->anchorSet($inx);
@@ -12741,10 +12783,11 @@ sub choose_ort {
     }
 
     if (defined $see) {
-	if ($splitter) {
+	if ($splitter || $addwidgetcb) {
 	TRY: {
 		for my $inx ($lb->info('children')) {
-		    if ($lb->itemCget($inx, 0, '-text') eq $see) {
+		    my $text = eval { $lb->itemCget($inx, 0, '-text') };
+		    if (defined $text && $text eq $see) {
 			$lb->see($inx);
 			$lb->anchorSet($inx);
 			last TRY;

--- a/plugins/SRTShortcuts.pm
+++ b/plugins/SRTShortcuts.pm
@@ -1745,6 +1745,7 @@ sub show_any_diff {
     $f = $t->Frame->pack(-fill => "both", -expand => 1);
 
     my(@columnwidths) = _vmz_lbvs_columnwidths();
+    push @columnwidths, 80;
     {
 	my $sum_columnwidths = 0;
 	my $joker_index;
@@ -1763,8 +1764,32 @@ sub show_any_diff {
 	}
     }
 
+    my $wrapped_splitter = sub {
+	my($line) = @_;
+	my(@cols) = _vmz_lbvs_splitter($line);
+	if (defined $cols[0] && (($cols[0] =~ /CHANGED/ && $cols[0] !~ /UNCHANGED/) || $cols[0] =~ /REMOVED/)) {
+	    my $id = $cols[2];
+	    push @cols, {
+		text => "Hist",
+		cb => sub {
+		    my ($lb, $col_val) = @_;
+		    return $lb->Button(
+			-text => "Hist",
+			-relief => 'flat',
+			-command => sub {
+			    _show_viz_history($id);
+			}
+		    );
+		}
+	    };
+	} else {
+	    push @cols, "";
+	}
+	return @cols;
+    };
+
     main::choose_ort("str", $abk,
-		     -splitter => \&_vmz_lbvs_splitter,
+		     -splitter => $wrapped_splitter,
 		     -columnwidths => \@columnwidths,
 		     # XXX Maybe implement -infocallback (an info
 		     # button in the choose_ort window) some time, but
@@ -1777,6 +1802,38 @@ sub show_any_diff {
 		     -container => $f,
 		     -ondestroy => sub { $t->destroy },
 		    );
+}
+
+sub _show_viz_history {
+    my ($id) = @_;
+    my $token = "vizhistory-$id";
+    my $t = main::redisplay_top($main::top, $token, -title => "History for ID $id");
+    if (!$t) {
+	$t = $main::toplevel{$token};
+	$_->destroy for ($t->children);
+    } else {
+	$t->geometry("600x400");
+    }
+
+    my $bf = $t->Frame->pack(-side => 'bottom', -fill => 'x');
+    $bf->Button(-text => "Close", -command => sub { $t->destroy })->pack(-pady => 5);
+
+    my $txt = $t->Scrolled("ROText", -scrollbars => "osoe")->pack(-fill => 'both', -expand => 1);
+
+    my $out = "";
+    eval {
+	my $root = bbbike_root();
+	open(my $fh, "-|", $^X, "$root/miscsrc/vizhistory", "--no-pager", $id)
+	    or die "Cannot execute vizhistory: $!";
+	local $/;
+	$out = <$fh>;
+	close($fh);
+    };
+    if ($@) {
+	$out = "Error: $@";
+    }
+
+    $txt->insert('end', $out);
 }
 
 sub _lbvs_info_callback {

--- a/plugins/SRTShortcuts.pm
+++ b/plugins/SRTShortcuts.pm
@@ -1769,6 +1769,7 @@ sub show_any_diff {
 	my(@cols) = _vmz_lbvs_splitter($line);
 	if (defined $cols[0] && (($cols[0] =~ /CHANGED/ && $cols[0] !~ /UNCHANGED/) || $cols[0] =~ /REMOVED/)) {
 	    my $id = $cols[2];
+	    my $clean_id = (split(' ', $id || ''))[0] || '';
 	    push @cols, {
 		text => "Hist",
 		cb => sub {
@@ -1776,8 +1777,12 @@ sub show_any_diff {
 		    return $lb->Button(
 			-text => "Hist",
 			-relief => 'flat',
+			-padx => 0,
+			-pady => 0,
+			-borderwidth => 1,
+			-highlightthickness => 0,
 			-command => sub {
-			    _show_viz_history($id);
+			    _show_viz_history($clean_id);
 			}
 		    );
 		}

--- a/t/BBBikeChooseOrtWidgetTest.pm
+++ b/t/BBBikeChooseOrtWidgetTest.pm
@@ -1,0 +1,79 @@
+# -*- perl -*-
+
+package BBBikeChooseOrtWidgetTest;
+
+use strict;
+use vars qw($VERSION);
+$VERSION = 1.00;
+
+use Time::HiRes ();
+use Test::More qw(no_plan);
+
+sub start_guitest {
+    my $end_time = Time::HiRes::time();
+    diag "Starting choose_ort addwidget GUI test...\n";
+
+    my $top = $main::top;
+    my $c   = $main::c;
+
+    # 1. Test choose_ort with -addwidgetcb
+    my $t1 = main::choose_ort('p', 'o',
+                             -addwidgetcb => sub {
+                                 my ($lb, $ort, $ort_idx) = @_;
+                                 return $lb->Button(-text => "MyBtn-$ort");
+                             },
+                             -popup => 0,
+                            );
+
+    ok(defined $t1, "choose_ort with -addwidgetcb returned a window");
+    my $lb1 = $t1->Subwidget("Listbox");
+    ok(defined $lb1, "Found HList widget in returned window");
+
+    my @children1 = $lb1->info('children');
+    cmp_ok(scalar(@children1), ">", 0, "HList contains entries");
+
+    my $first_item1 = $children1[0];
+    my $widget1 = $lb1->itemCget($first_item1, 1, '-window');
+    ok(defined $widget1, "Widget at column 1 is defined for -addwidgetcb");
+    isa_ok($widget1, 'Tk::Button', "Widget at column 1 is a Tk::Button");
+
+    my $text1 = $lb1->itemCget($first_item1, 0, '-text');
+    is($widget1->cget('-text'), "MyBtn-$text1", "Button text matches generated text");
+
+    # 2. Test choose_ort with -splitter returning Hashrefs with cb
+    my $t2 = main::choose_ort('p', 'o',
+                              -splitter => sub {
+                                  my ($ort, $ort_idx) = @_;
+                                  return ($ort, { text => "Btn-$ort", cb => sub {
+                                      my ($lb, $col_val) = @_;
+                                      return $lb->Button(-text => $col_val->{text});
+                                  }});
+                              },
+                              -popup => 0,
+                              -rebuild => 1,
+                             );
+
+    ok(defined $t2, "choose_ort with splitter returned a window");
+    my $lb2 = $t2->Subwidget("Listbox");
+    ok(defined $lb2, "Found HList widget in splitter window");
+
+    my @children2 = $lb2->info('children');
+    cmp_ok(scalar(@children2), ">", 0, "Splitter HList contains entries");
+
+    my $first_item2 = $children2[0];
+    my $widget2 = $lb2->itemCget($first_item2, 1, '-window');
+    ok(defined $widget2, "Widget at column 1 is defined for splitter Hashref");
+    isa_ok($widget2, 'Tk::Button', "Widget at column 1 is a Tk::Button");
+
+    my $text2 = $lb2->itemCget($first_item2, 0, '-text');
+    is($widget2->cget('-text'), "Btn-$text2", "Splitter Button text matches generated text");
+
+    # Clean up and exit
+    $t1->destroy if Tk::Exists($t1);
+    $t2->destroy if Tk::Exists($t2);
+
+    diag "All tests passed successfully! Exiting...\n";
+    main::exit_app_noninteractive();
+}
+
+1;

--- a/t/choose_ort-addwidget.t
+++ b/t/choose_ort-addwidget.t
@@ -1,0 +1,21 @@
+#!/usr/bin/perl -w
+# -*- cperl -*-
+
+use strict;
+use FindBin;
+use lib ($FindBin::RealBin, "$FindBin::RealBin/..");
+use BBBikeTest qw(check_gui_testing);
+check_gui_testing;
+use Time::HiRes ();
+
+$ENV{BBBIKE_GUI_TEST_MODULE} = 'BBBikeChooseOrtWidgetTest';
+chdir "$FindBin::RealBin/.." or die $!;
+if ($^O eq 'MSWin32') {
+    $ENV{LC_MESSAGES} = $ENV{LC_ALL} = 'German_Germany.1252';
+} else {
+    $ENV{LC_ALL} = $ENV{LANG} = 'de_DE.UTF-8';
+}
+$ENV{BBBIKE_TEST_STARTTIME} = Time::HiRes::time();
+exec $^X, '-It', 'bbbike', '-public';
+
+__END__


### PR DESCRIPTION
Adds support to 'choose_ort' in bbbike for showing custom widgets/buttons in columns when using a multicolumn view (HList). This is implemented via a new -addwidgetcb callback option and by supporting Hashrefs with a 'cb' callback in the -splitter columns list. It also includes comprehensive automated GUI tests verifying both implementation paths.

---
*PR created automatically by Jules for task [2260410288639346636](https://jules.google.com/task/2260410288639346636) started by @eserte*