### PR TITLE
Add configurable --ubuntu-mirror option in docker-bbbike

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,6 +177,7 @@ jobs:
         set -e
         sudo apt-get install -y libipc-run-perl
         ./miscsrc/docker-bbbike test --dist ${{ matrix.dist }} --distver ${{ matrix.distver }} --src local --jobs 8 \
+            --ubuntu-mirror http://debian.charite.de/ubuntu/ \
             --env BBBIKE_TEST_SKIP_MAPSERVER=${{ matrix.bbbike_test_skip_mapserver }} \
             --env USE_ESERTE_OBS=${{ matrix.use_eserte_obs }} \
             --env USE_BBBIKE_PPA=${{ matrix.use_bbbike_ppa }} \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,7 +177,7 @@ jobs:
         set -e
         sudo apt-get install -y libipc-run-perl
         ./miscsrc/docker-bbbike test --dist ${{ matrix.dist }} --distver ${{ matrix.distver }} --src local --jobs 8 \
-            --ubuntu-mirror http://debian.charite.de/ubuntu/ \
+            --ubuntu-mirror http://ftp.halifax.rwth-aachen.de/ubuntu/ \
             --env BBBIKE_TEST_SKIP_MAPSERVER=${{ matrix.bbbike_test_skip_mapserver }} \
             --env USE_ESERTE_OBS=${{ matrix.use_eserte_obs }} \
             --env USE_BBBIKE_PPA=${{ matrix.use_bbbike_ppa }} \

--- a/miscsrc/docker-bbbike
+++ b/miscsrc/docker-bbbike
@@ -60,7 +60,7 @@ sub usage_gui (;$) {
     die((defined $_[0] ? $_[0]."\n\n" : '') . <<EOF);
 usage: $0 [--dry-run] gui [--dist debian|ubuntu|...] [--distver bullseye|...] [--src local|github|github-fixed|github-archive|bbbike...deb] [--bbbike-prog ...] [--bbbike-args "..."] [--branch ...]
 	 [--no-feature-pdf] [--no-feature-svg] [-no-feature-remote]
-	 [--debug] [--no-install-recommends] [--install-suggests] [--invalidate-apt] [--docker-image owner/name:tag] [--share-data-osm] [--copy-bikepowerrc] [--hack-writable-data]
+	 [--debug] [--no-install-recommends] [--install-suggests] [--invalidate-apt] [--docker-image owner/name:tag] [--share-data-osm] [--copy-bikepowerrc] [--hack-writable-data] [--ubuntu-mirror <mirror>]
 
 Note that --install-suggests would install quite a lot...
 EOF
@@ -69,7 +69,7 @@ EOF
 sub usage_ci (;$) {
     die((defined $_[0] ? $_[0]."\n\n" : '') . <<EOF);
 usage: $0 [--dry-run] ci [--dist debian|ubuntu|...] [--distver stretch|...] [--src local|github] [--perl-ver X.Y.Z] [--env KEY=VAL ...] [--branch ...]
-	 [--with-data-build] [--no-cache] [--invalidate-apt] [--image-variant ...] [--docker-build-max-retry ...]
+	 [--with-data-build] [--no-cache] [--invalidate-apt] [--image-variant ...] [--docker-build-max-retry ...] [--ubuntu-mirror <mirror>]
 EOF
 }
 
@@ -83,7 +83,7 @@ EOF
 sub usage_cgi (;$) {
     die((defined $_[0] ? $_[0]."\n\n" : '') . <<EOF);
 usage: $0 [--dry-run] cgi [--dist debian|ubuntu|...] [--distver stretch|...] [--test]
-	 [--invalidate-apt] [--[no]mapserver] [--use-bbbike-ppa] [--no-force-ipv4]
+	 [--invalidate-apt] [--[no]mapserver] [--use-bbbike-ppa] [--no-force-ipv4] [--ubuntu-mirror <mirror>]
 EOF
 }
 
@@ -144,6 +144,15 @@ EOF
 RUN perl -i -pe 's{http://archive.ubuntu.com/}{http://old-releases.ubuntu.com/}g' /etc/apt/sources.list $(perl -e 'print </etc/apt/sources.list.d/*.list>')
 EOF
     }
+
+    if ($optref->{'ubuntu-mirror'}) {
+	my $mirror = $optref->{'ubuntu-mirror'};
+	$mirror =~ s{/$}{};
+	$dockerfile .= <<"EOF";
+RUN perl -le 'for my \$f ("/etc/apt/sources.list", glob("/etc/apt/sources.list.d/*.list"), glob("/etc/apt/sources.list.d/*.sources")) { if (-f \$f) { system("perl", "-i", "-pe", "s{https?://[^/]*ubuntu\\\\.com/ubuntu(?=/|\\\$)}{$mirror}g", \$f) } }'
+EOF
+    }
+
     $dockerfile;
 }
 
@@ -1217,6 +1226,7 @@ if ($subcmd =~ m{^(gui|perl[-_]?tk)$}) {
 	       'share-data-osm' => 0,
 	       'hack-writable-data' => 0,
 	       'copy-bikepowerrc' => 0,
+	       'ubuntu-mirror' => undef,
 	      );
     GetOptions(\%opt,
 	       "dist=s",
@@ -1237,6 +1247,7 @@ if ($subcmd =~ m{^(gui|perl[-_]?tk)$}) {
 	       'share-data-osm!',
 	       'hack-writable-data!',
 	       'copy-bikepowerrc!',
+	       'ubuntu-mirror=s',
 	      )
 	or usage_gui;
     gui($doit, %opt);
@@ -1257,6 +1268,7 @@ if ($subcmd =~ m{^(gui|perl[-_]?tk)$}) {
 	       'image-variant' => undef,
 	       'cover-dir' => undef,
 	       'docker-build-max-retry' => undef,
+	       'ubuntu-mirror' => undef,
 	      );
     GetOptions(\%opt,
 	       "jobs|j=i",
@@ -1274,6 +1286,7 @@ if ($subcmd =~ m{^(gui|perl[-_]?tk)$}) {
 	       'image-variant=s',
 	       'cover-dir=s',
 	       'docker-build-max-retry=i',
+	       'ubuntu-mirror=s',
 	      )
 	or usage_ci;
     _check_distver $opt{distver};
@@ -1304,6 +1317,7 @@ if ($subcmd =~ m{^(gui|perl[-_]?tk)$}) {
 	       mapserver => 0,
 	       'use-bbbike-ppa' => undef,
 	       'force-ipv4' => 1,
+	       'ubuntu-mirror' => undef,
 	      );
     GetOptions(\%opt,
 	       "dist=s",
@@ -1313,6 +1327,7 @@ if ($subcmd =~ m{^(gui|perl[-_]?tk)$}) {
 	       'mapserver!',
 	       'use-bbbike-ppa!',
 	       'force-ipv4!',
+	       'ubuntu-mirror=s',
 	      )
 	or usage_cgi;
     cgi($doit, %opt);


### PR DESCRIPTION
Introduces a configurable `--ubuntu-mirror` command-line option in `miscsrc/docker-bbbike` (for subcommands `gui`, `ci`/`test`, and `cgi`/`web`), and configures the `test_in_container` job in `.github/workflows/test.yml` to use `http://debian.charite.de/ubuntu/`. This avoids slow-downs on the official Ubuntu mirrors and is extremely easy to revert by removing the `--ubuntu-mirror` flag.

---
*PR created automatically by Jules for task [15114715754531719541](https://jules.google.com/task/15114715754531719541) started by @eserte*