### PR TITLE
Skip px_1t.gif check in t/images.t on problematic libgif7

### DIFF
--- a/t/images.t
+++ b/t/images.t
@@ -23,6 +23,7 @@ BEGIN {
 }
 
 use BBBikeTest qw(image_ok);
+use BBBikeUtil qw(is_in_path);
 
 plan 'no_plan';
 
@@ -39,6 +40,7 @@ for (glob("*.*")) {
 }
 
 sub should_skip_px_1t_gif {
+    return 0 if !is_in_path('dpkg-query') || !is_in_path('dpkg');
     my $libgif_version = `dpkg-query -W -f='\${Version}' libgif7 2>/dev/null`;
     if (defined $libgif_version && length $libgif_version) {
         chomp $libgif_version;

--- a/t/images.t
+++ b/t/images.t
@@ -30,7 +30,24 @@ chdir "$FindBin::RealBin/../images" or die $!;
 for (glob("*.*")) {
     next if /\.(svg|xcf)$/;
     next if /\.xpm$/; # XXX xpmtoppm cannot handle the color "opaque"
-    image_ok($_, $_);
+    SKIP: {
+        if ($_ eq 'px_1t.gif' && should_skip_px_1t_gif()) {
+            Test::More::skip("px_1t.gif fails with problematic libgif7 version", 2);
+        }
+        image_ok($_, $_);
+    }
+}
+
+sub should_skip_px_1t_gif {
+    my $libgif_version = `dpkg-query -W -f='\${Version}' libgif7 2>/dev/null`;
+    if (defined $libgif_version && length $libgif_version) {
+        chomp $libgif_version;
+        my $rc = system('dpkg', '--compare-versions', $libgif_version, 'ge', '5.2.2-1ubuntu1.2');
+        if ($rc == 0) {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 __END__


### PR DESCRIPTION
Skips px_1t.gif check in t/images.t on Debian/Ubuntu systems running libgif7 >= 5.2.2-1ubuntu1.2 because security patches break loading of this 1x1 interlaced transparent GIF.

---
*PR created automatically by Jules for task [3161275332486295817](https://jules.google.com/task/3161275332486295817) started by @eserte*