### PR TITLE
bbbike-grep: search also for reversed coordinates

### DIFF
--- a/miscsrc/bbbike-grep
+++ b/miscsrc/bbbike-grep
@@ -65,6 +65,7 @@ my @search_org_files;
 
 my $searchterm_type = 'fixed';
 my $case_insens     = 1;
+my $also_reverse_coords = 1;
 my $limit;
 
 my $with_filename = 1;
@@ -97,6 +98,7 @@ GetOptions(
 	   },
 	   'add-org-file=s@'       => \@search_org_files,
 	   'reldir=s'              => \my $reldir,
+	   'also-reverse-coords|also-reverse-coordinates!' => \$also_reverse_coords,
 	   'debug'                 => \$debug,
 	  )
     or die "usage?";
@@ -106,13 +108,37 @@ my $searchterm = shift
     or die "usage? searchterm missing";
 my $original_searchterm = $searchterm;
 
-if ($searchterm_type eq 'fixed') {
-    $searchterm = quotemeta($searchterm);
+my $is_coord_series = 0;
+if ($also_reverse_coords) {
+    my $number_rx     = qr{[+-]?(?:\d+(?:\.\d+)?|\.\d+)};
+    my $coord_pair_rx = qr{$number_rx\s*,\s*$number_rx};
+    if ($searchterm =~ m{^\s*$coord_pair_rx(?:\s+$coord_pair_rx)+\s*$}s) {
+	my @coords = $searchterm =~ m{($coord_pair_rx)}g;
+	if (@coords >= 2) {
+	    my $fwd_term = join(" ", @coords);
+	    my $rev_term = join(" ", reverse @coords);
+	    if ($fwd_term ne $rev_term) {
+		$is_coord_series = 1;
+		if ($searchterm_type eq 'fixed') {
+		    $searchterm = "(?:" . quotemeta($fwd_term) . "|" . quotemeta($rev_term) . ")";
+		} else {
+		    $searchterm = "(?:$fwd_term|$rev_term)";
+		}
+	    }
+	}
+    }
 }
-# maybe do this conditional/with option?
-# str. <-> straße
-$searchterm =~ s{(?<=[sS]tr)\\\.}{(\\.|aße)}g;
-$searchterm =~ s{(?<=[sS]tr)aße}{(\\.|aße)}g;
+
+if (!$is_coord_series) {
+    if ($searchterm_type eq 'fixed') {
+	$searchterm = quotemeta($searchterm);
+    }
+    # maybe do this conditional/with option?
+    # str. <-> straße
+    $searchterm =~ s{(?<=[sS]tr)\\\.}{(\\.|aße)}g;
+    $searchterm =~ s{(?<=[sS]tr)aße}{(\\.|aße)}g;
+}
+
 if ($searchterm ne $original_searchterm) {
     debug "searchterm was changed from '$original_searchterm' to '$searchterm'";
 }
@@ -394,6 +420,13 @@ set of files.
 
 Specify an org-mode file to search, additionally to the standard set
 of files.
+
+=item C<--also-reverse-coords>, C<--no-also-reverse-coords> (alias: C<--[no-]also-reverse-coordinates>)
+
+If the search term looks like a series of coordinates (space-separated
+x,y or lon,lat pairs, integer or float, negative or positive, at least
+two pairs), then automatically include the reversed sequence of coordinates
+in the search regex. Enabled by default.
 
 =item C<--debug>
 

--- a/t/bbbike-grep.t
+++ b/t/bbbike-grep.t
@@ -1,0 +1,86 @@
+#!/usr/bin/env perl
+# -*- perl -*-
+
+#
+# Author: Slaven Rezic
+#
+# Copyright (C) 2026 Slaven Rezic. All rights reserved.
+# This program is free software; you can redistribute it and/or
+# modify it under the same terms as Perl itself.
+#
+# WWW:  https://github.com/eserte/bbbike
+#
+
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::RealBin/..", "$FindBin::RealBin/../lib";
+
+use File::Temp qw(tempfile);
+use Test::More tests => 15;
+
+my ($tfh, $testfile) = tempfile(UNLINK => 1);
+print $tfh <<'EOF';
+Street A	NN 1000,2000 1100,2100 1200,2200
+Street B	NN 13.405,52.520 13.406,52.521 13.407,52.522
+Street C	NN -10.5,+20.5 -11.5,+21.5
+Street D	NN 500,600
+EOF
+close $tfh;
+
+my $bbbike_grep_cmd = "$^X -I$FindBin::RealBin/.. -I$FindBin::RealBin/../lib $FindBin::RealBin/../miscsrc/bbbike-grep";
+
+{
+    my $cmd = "$bbbike_grep_cmd -h --add-file $testfile -- \"Street A\"";
+    my $output = `$cmd`;
+    is($? >> 8, 0, "Exit status 0 for standard text search");
+    like($output, qr/Street A/, "Found Street A via text search");
+}
+
+{
+    my $cmd = "$bbbike_grep_cmd -h --add-file $testfile -- \"1000,2000 1100,2100\"";
+    my $output = `$cmd`;
+    is($? >> 8, 0, "Exit status 0 for forward coordinate search");
+    like($output, qr/Street A/, "Found Street A via forward coordinate search");
+}
+
+{
+    my $cmd = "$bbbike_grep_cmd -h --add-file $testfile -- \"1100,2100 1000,2000\"";
+    my $output = `$cmd`;
+    is($? >> 8, 0, "Exit status 0 for reversed coordinate search (default)");
+    like($output, qr/Street A/, "Found Street A via reversed coordinate search");
+}
+
+{
+    my $cmd = "$bbbike_grep_cmd -h --no-also-reverse-coords --add-file $testfile -- \"1100,2100 1000,2000\"";
+    my $output = `$cmd`;
+    isnt($? >> 8, 0, "Exit status non-zero with --no-also-reverse-coords for reversed coordinates");
+    unlike($output, qr/Street A/, "Street A not found when --no-also-reverse-coords is active");
+}
+
+{
+    my $cmd = "$bbbike_grep_cmd -h --no-also-reverse-coordinates --add-file $testfile -- \"1100,2100 1000,2000\"";
+    my $output = `$cmd`;
+    isnt($? >> 8, 0, "Exit status non-zero with --no-also-reverse-coordinates alias");
+}
+
+{
+    my $cmd = "$bbbike_grep_cmd -h --add-file $testfile -- \"13.406,52.521 13.405,52.520\"";
+    my $output = `$cmd`;
+    is($? >> 8, 0, "Exit status 0 for reversed float coordinates");
+    like($output, qr/Street B/, "Found Street B via reversed float coordinates");
+}
+
+{
+    my $cmd = "$bbbike_grep_cmd -h --add-file $testfile -- \"-11.5,+21.5 -10.5,+20.5\"";
+    my $output = `$cmd`;
+    is($? >> 8, 0, "Exit status 0 for reversed signed coordinates");
+    like($output, qr/Street C/, "Found Street C via reversed signed coordinates");
+}
+
+{
+    my $cmd = "$bbbike_grep_cmd -h --rx --add-file $testfile -- \"1100,2100 1000,2000\"";
+    my $output = `$cmd`;
+    is($? >> 8, 0, "Exit status 0 for reversed coordinate search in rx mode");
+    like($output, qr/Street A/, "Found Street A in rx mode");
+}


### PR DESCRIPTION
Add --also-reverse-coords option (enabled by default) to bbbike-grep to search for reversed coordinate sequences when the search term is a series of coordinates.

---
*PR created automatically by Jules for task [10972187035295223520](https://jules.google.com/task/10972187035295223520) started by @eserte*